### PR TITLE
fix: contributor link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you want to contribute to this project, you can do so by reading the [Contrib
 
 **Thanks to all the contributors who have made this project possible!**
 
-[![Contributors](https://contrib.rocks/image?repo=Afordin/web-afordin&)](https://github.com/Afordin/web-afordin&/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=Afordin/web-afordin&)](https://github.com/Afordin/web-afordin/graphs/contributors)
 
 ## 🛠️ Stack
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Afordin is the best programming and web design community in the world where crea
   - [🤝 Contribute](#-contribute)
   - [👥 Authors](#-authors)
   - [🛠️ Stack](#️-stack)
-  
+
 ## 🚀 Getting Started
 
 1. Clone or fork this repository
@@ -83,7 +83,7 @@ If you want to contribute to this project, you can do so by reading the [Contrib
 
 **Thanks to all the contributors who have made this project possible!**
 
-[![Contributors](https://contrib.rocks/image?repo=Afordin/web-afordin)](https://github.com/Afordin/web-afordin/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=Afordin/web-afordin&)](https://github.com/Afordin/web-afordin&/graphs/contributors)
 
 ## 🛠️ Stack
 


### PR DESCRIPTION
This pull request fixes a bug in the Contributors section of the README.
![image](https://github.com/user-attachments/assets/8c0effeb-78b9-46ba-91a1-1d1eec20d57a)
