### PR TITLE
fix: image source paths in `Values.astro` to remove redundant `/public` prefix

### DIFF
--- a/src/components/Values.astro
+++ b/src/components/Values.astro
@@ -2,17 +2,17 @@
   <h2 class="text-[48px] font-bold">Nuestros valores</h2>
   <div class="flex">
     <div class="m-5 flex h-full w-full flex-col bg-amber-700 p-4">
-      <img src="/public/personpc.svg" alt="personpc" class="size-fit" />
+      <img src="/personpc.svg" alt="personpc" class="size-fit" />
       <h3 class="text-[28px] font-bold">Aprendizaje libre</h3>
       <p>Poder aprender sin la presión de un entorno laboral. Adaptación a los contribuidores</p>
     </div>
     <div class="m-5 flex h-full w-full flex-col bg-amber-700 p-4">
-      <img src="/public/messages.svg" alt="messages" />
+      <img src="/messages.svg" alt="messages" />
       <h3 class="text-[28px] font-bold">Conocimiento compartido</h3>
       <p class="text-[18px]">Poder aprender sin la presión de un entorno laboral. Adaptación a los contribuidores</p>
     </div>
     <div class="m-5 flex h-full w-full flex-col bg-amber-700 p-4">
-      <img src="/public/personStairs.svg" alt="personStairs" class="size-fit" />
+      <img src="/personStairs.svg" alt="personStairs" class="size-fit" />
       <h3 class="text-[28px] font-bold">Superacion segura</h3>
       <p class="text-[18px]">Poder aprender sin la presión de un entorno laboral. Adaptación a los contribuidores</p>
     </div>


### PR DESCRIPTION
Este pull request incluye un cambio pequeño pero importante en las rutas de los archivos de imágenes en `src/components/Values.astro`. Los atributos `src` de tres elementos `<img>` fueron actualizados para eliminar el prefijo `/public`, asegurando que las rutas se resuelvan correctamente para evitar este mensaje en consola.

![image](https://github.com/user-attachments/assets/4c4ffa46-47f1-4e15-b442-114ed5a6465c)
