### PR TITLE
chore: add ignore-workspace-root-check to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+ignore-workspace-root-check=true


### PR DESCRIPTION
Este pull request incluye un pequeño cambio en el archivo `.npmrc`. El cambio añade la configuración `ignore-workspace-root-check=true` para permitir la instalación de paquetes en la raíz del proyecto. Esto es necesario porque @afordigital no tiene PNPM actualizado. 😄