### PR TITLE
fix: path to logo

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -35,7 +35,7 @@ const socialLinks = [
 ---
 
 <nav class="absolute top-5 z-50 flex items-center justify-between gap-5 rounded-full bg-white/30 p-4">
-  <img src="./public/logo.png" alt="" />
+  <img src="/logo.png" alt="" />
   {links.map((link) => <a href={link.href}>{link.name}</a>)}
   {
     socialLinks.map((link) => (


### PR DESCRIPTION
Warn on nav component
- Files in the public directory are served at the root path.
- Instead of /public/logo.png, use /logo.png.