### PR TITLE
fix: amended a translation "Proyectos" instead of "Valores"

### DIFF
--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -32,7 +32,7 @@ export const ui = {
     // nav
     'nav.home': 'Inicio',
     'nav.values': 'Valores',
-    'nav.projects': 'Valores',
+    'nav.projects': 'Proyectos',
     'nav.events': 'Eventos',
     'nav.contributor': 'Contribuyentes',
     // footer


### PR DESCRIPTION
Una traducción estaba mal, la opción "Valores" se repetía  dos veces. Hice el cambio por "Proyectos" como se indica en Figma.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/d79528c3-b83d-41fd-b4cd-22fcccebc5c5" />
