### PR TITLE
fix: footer contributors fetching

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,6 +2,7 @@
 import FooterContributors from './FooterContributors.astro'
 import FooterDesignersContributors from './FooterDesignersContributors.astro'
 import type { Contributor } from '@/types/index.d'
+import { fetchGithub } from '../utils/fetchGithub'
 import { designersData } from '@/data/designersData'
 import Discord from '@/assets/Discord.svg'
 import Youtube from '@/assets/Youtube.svg'
@@ -10,8 +11,9 @@ import { getLangFromUrl, useTranslations } from '@/i18n/utils'
 import SelectLanguage from './ui/SelectLanguage.astro'
 import Link from '@/components/Link.astro'
 
-const response = await fetch(`https://api.github.com/repos/Afordin/web-afordin/contributors`)
-const dataDevs: Array<Contributor> = await response.json()
+let dataDevs: Array<Contributor> = []
+
+dataDevs = await fetchGithub('Afordin/web-afordin')
 
 const lang = getLangFromUrl(Astro.url)
 const t = useTranslations(lang)
@@ -111,7 +113,13 @@ const links = [
         </div>
         <div class="contend-end flex flex-col items-center gap-4 lg:items-end">
           <h3 class="text-base">{t('footer.title.developers')}</h3>
-          <FooterContributors contributors={dataDevs} />
+          {
+            dataDevs?.length > 0 ? (
+              <FooterContributors contributors={dataDevs} />
+            ) : (
+              <p class="text-sm text-white">Contribuidores no disponibles en este momento</p>
+            )
+          }
         </div>
       </div>
     </div>

--- a/src/utils/fetchGithub.ts
+++ b/src/utils/fetchGithub.ts
@@ -1,0 +1,12 @@
+import type { Contributor } from '@/types/index.d'
+
+export const fetchGithub = async (repo: string): Promise<Contributor[]> => {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${repo}/contributors`)
+    const contributors = await response.json()
+    return contributors
+  } catch (error) {
+    console.error('Error fetching data:', error)
+    return []
+  }
+}


### PR DESCRIPTION
Este pull request resuelve el error que se producía al momento de obtener data desde Github

# Descripción

- Se creó una función para obtener la data desde la api de Github, manejando try and catch
![image](https://github.com/user-attachments/assets/8432d875-1309-47a7-bab8-98d4b6e83731)

- Ahora el array se inicializa vacío para no ocasionar problemas al hacer map
![image](https://github.com/user-attachments/assets/c154d6d0-cb14-4637-925b-18dc592ceb3a)

- Adicionalmente se hace una comprobación final para ver si los contribuidores fueron obtenidos o no, y en caso de no estar presentes por fallos en la api, muestra un texto indicando que no fue posible obtener los contribuidores
![image](https://github.com/user-attachments/assets/7281b276-d750-40c9-8c15-c841e4ff54a7)
