### PR TITLE
fix: add missing pnpm-lock.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pnpm-debug.log*
 
 # node.js
 package-lock.json
+pnpm-lock.yaml
 yarn.lock
 
 # bun


### PR DESCRIPTION
Se añade el archivo `pnpm-lock.yaml` faltante al `.gitignore`