### PR TITLE
feat: create placeholder generation and custom image component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn.lock
 
 # bun
 bun.lockb
+
+# placeholders data
+src/data/placeholders.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save-exact=true
 ignore-workspace-root-check=true
+enable-pre-post-scripts=true

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,13 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
+    build: {
+      rollupOptions: {
+        output: {
+          assetFileNames: '_astro/[name].[ext]',
+        },
+      },
+    },
   },
   experimental: {
     fonts: [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,7 @@ export default [
       '@typescript-eslint/triple-slash-reference': 'off',
       '@typescript-eslint/no-unsafe-type-assertion': 'off',
       '@typescript-eslint/no-unnecessary-type-parameters': 'off',
-      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      'no-console': ['warn', { allow: ['info', 'warn', 'error'] }],
     },
   },
   configPrettier,

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "version": "0.0.1",
   "scripts": {
     "astro": "astro",
+    "predev": "pnpm placeholder",
     "dev": "astro dev",
     "preview": "astro preview",
     "lint": "eslint --cache \"src/**/*.{astro,ts}\"",
     "lint:fix": "eslint --cache \"src/**/*.{astro,ts}\" --fix",
+    "prebuild": "pnpm placeholder",
     "build": "pnpm check && astro build",
     "check": "astro check --tsconfig tsconfig.json",
     "format": "prettier --cache --write \"./**/*.{js,mjs,css,ts,astro,json,svg,yaml,yml}\"",
+    "placeholder": "node src/scripts/placeholder.js",
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
   "dependencies": {
     "astro": "5.7.4",
     "clsx": "2.1.1",
+    "sharp": "0.34.1",
     "tailwind-merge": "3.2.0"
   },
   "devDependencies": {
     "@astrojs/check": "0.9.4",
     "@tailwindcss/vite": "4.1.4",
+    "@types/node": "22.15.3",
     "@typescript-eslint/eslint-plugin": "8.31.0",
     "@typescript-eslint/parser": "8.31.0",
     "eslint": "9.25.1",

--- a/src/components/ui/Image.astro
+++ b/src/components/ui/Image.astro
@@ -1,0 +1,46 @@
+---
+import type { GetImageResult } from 'astro'
+
+import { getPlaceholder } from '@/utils/getPlaceholder'
+import { getImage } from '@/utils/getImage'
+
+import { Image as AstroImage } from 'astro:assets'
+
+interface Props {
+  src: string
+  alt: string
+  class?: string
+}
+
+const { src, alt, class: className, ...rest } = Astro.props
+
+let image: GetImageResult['src'] | null = null
+let placeholder: GetImageResult['src'] | null = null
+
+try {
+  image = (await getImage({ src })) as GetImageResult['src']
+  const placeholderResult = await getPlaceholder(image)
+  placeholder = typeof placeholderResult === 'string' ? placeholderResult : null
+} catch (error) {
+  console.error('Error loading image or placeholder:', error)
+}
+---
+
+<div class="relative overflow-hidden">
+  <AstroImage
+    src={placeholder || ''}
+    alt={`${alt} - placeholder`}
+    inferSize
+    class="pointer-events-none absolute inset-0 h-full w-full transform opacity-100 blur-sm transition-opacity duration-300 ease-in-out"
+    aria-hidden="true"
+  />
+
+  <AstroImage
+    src={image || ''}
+    alt={alt}
+    class:list={['h-auto w-full object-cover opacity-0 transition-opacity duration-300 ease-in-out', className]}
+    onload="this.classList.remove('opacity-0'); this.previousElementSibling.classList.replace('opacity-100', 'opacity-0')"
+    inferSize
+    {...rest}
+  />
+</div>

--- a/src/scripts/placeholder.js
+++ b/src/scripts/placeholder.js
@@ -1,0 +1,66 @@
+import { readdir, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve, extname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import sharp from 'sharp'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PUBLIC_DIR = join(__dirname, '../../public')
+const FILE = join(__dirname, '../data/placeholders.json')
+
+const EXTENSIONS = ['.jpg', '.jpeg', '.png', '.svg']
+
+async function generateBlurPlaceholder(imagePath) {
+  try {
+    const imageBuffer = await sharp(imagePath).resize(10).webp({ quality: 10 }).toBuffer()
+
+    // convert to base64
+    return `data:image/webp;base64,${imageBuffer.toString('base64')}`
+  } catch (error) {
+    console.error(`Error processing ${imagePath}:`, error)
+    return null
+  }
+}
+
+async function* walkDirectory(dir) {
+  const files = await readdir(dir, { withFileTypes: true })
+  for (const file of files) {
+    const res = resolve(dir, file.name)
+    if (file.isDirectory()) {
+      yield* walkDirectory(res)
+    } else {
+      yield res
+    }
+  }
+}
+
+async function generatePlaceholders() {
+  const placeholderData = {}
+  let count = 0
+
+  try {
+    for await (const filePath of walkDirectory(PUBLIC_DIR)) {
+      const ext = extname(filePath).toLowerCase()
+      if (EXTENSIONS.includes(ext)) {
+        const relativePath = relative(PUBLIC_DIR, filePath)
+        console.info(`Processing: ${relativePath}`)
+
+        const placeholder = await generateBlurPlaceholder(filePath)
+        if (placeholder) {
+          placeholderData[`/${relativePath}`] = placeholder
+          count++
+        }
+      }
+    }
+
+    // save placeholders to JSON file
+    await writeFile(FILE, JSON.stringify(placeholderData, null, 2))
+
+    console.info(`✅ Generated placeholders for ${count} images`)
+    console.info(`📝 Data saved in ${relative(process.cwd(), FILE)}`)
+  } catch (error) {
+    console.error('Error generating placeholders:', error)
+    process.exit(1)
+  }
+}
+
+generatePlaceholders()

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,3 +1,5 @@
+import type { LocalImageProps, RemoteImageProps } from 'astro:assets'
+
 export interface Contributor {
   login: string
   avatar_url: string
@@ -5,3 +7,6 @@ export interface Contributor {
 }
 
 export type contributorsIcons = 'linkedin' | 'github'
+
+export type Image = Awaited<LocalImageProps['src']> | Awaited<RemoteImageProps['src']>
+export type ImagePromise = Promise<LocalImageProps['src'] | RemoteImageProps['src']>

--- a/src/utils/getImage.ts
+++ b/src/utils/getImage.ts
@@ -1,0 +1,63 @@
+import type { ImageMetadata, UnresolvedImageTransform } from 'astro'
+import type { ImagePromise } from '@/types'
+
+import { getImage as externalImage } from 'astro:assets'
+
+async function getExternalImage(options: UnresolvedImageTransform): Promise<ImageMetadata | string> {
+  try {
+    const image = await externalImage({
+      ...options,
+      inferSize: true,
+      format: 'webp',
+    })
+    const { src } = image
+
+    return src
+  } catch (error) {
+    console.error('Error fetching external image:', error)
+
+    throw new Error('Failed to fetch external image.')
+  }
+}
+
+async function getLocalImage(imageUrl: string): Promise<ImageMetadata | string> {
+  try {
+    const getImages = import.meta.glob<{ default: ImageMetadata }>('../../public/**/*.{jpg,jpeg,png,svg}')
+
+    const formatImagePath = `../../public${imageUrl}`
+
+    // get image object from the import.meta.glob
+    const images = await getImages[formatImagePath as keyof typeof getImages]()
+    const { default: image } = images
+
+    return image
+  } catch (error) {
+    console.error('Error getting local image:', error)
+
+    throw new Error('Failed to get local image.')
+  }
+}
+
+export async function getImage(options: UnresolvedImageTransform): ImagePromise {
+  try {
+    const { src: image } = options
+
+    // return the image if it's an object
+    if (typeof image === 'object' && 'src' in image) {
+      return image
+    }
+
+    // check if the image path is an external image, if so, return the image URL
+    const isExternalImage = typeof image === 'string' && image.startsWith('http')
+    if (isExternalImage) {
+      return await getExternalImage(options)
+    }
+
+    // return the local image
+    return await getLocalImage(image as string)
+  } catch (error) {
+    console.error('Error in getImage function:', error)
+
+    throw new Error('Failed to resolve the image.')
+  }
+}

--- a/src/utils/getPlaceholder.ts
+++ b/src/utils/getPlaceholder.ts
@@ -1,0 +1,18 @@
+import type { ImageMetadata } from 'astro'
+import type { Image, ImagePromise } from '@/types'
+
+import placeholders from '@/data/placeholders.json'
+
+import { getImage } from '@/utils/getImage'
+
+export async function getPlaceholder(placeholderImage: Image): ImagePromise {
+  const placeholder = typeof placeholderImage === 'string' ? placeholderImage : (placeholderImage as ImageMetadata).src
+
+  const placeholderKey = Object.keys(placeholders).find((key) => placeholder.includes(key))
+
+  if (placeholderKey) {
+    return placeholders[placeholderKey as keyof typeof placeholders]
+  }
+
+  return getImage({ src: placeholder, format: 'webp' })
+}


### PR DESCRIPTION
> [!IMPORTANT]  
> Este es un trabajo en proceso (WIP), no se debe mergear a `main` hasta verificar el funcionamiento correcto en todas las imágenes.

Este pull request incluye un nuevo sistema de generación de placeholder para imágenes.

### Mejoras en el Manejo de Imágenes:
* Se añadió un nuevo componente `Image.astro` que soporta la visualización de imágenes con placeholder para un mejor rendimiento de carga, mostrando el placeholder antes de que la imagen completa se cargue (`src/components/ui/Image.astro`).
* Se implementó un script `placeholder.js` para generar placeholders en base64 para todas las imágenes en el directorio `public`, guardando los datos en un archivo JSON (`src/scripts/placeholder.js`).
* Se añadieron funciones utilitarias `getImage` y `getPlaceholder` para obtener y resolver imágenes (locales o externas) y sus placeholders (`src/utils/getImage.ts`, `src/utils/getPlaceholder.ts`). [[1]](diffhunk://#diff-4521e454e77ba005b43cf1edd2e0e85599796c8c3480c7c594c963b75dbe20a8R1-R63) [[2]](diffhunk://#diff-84a097c08423ef417480795d456fce72ed38748b6f4bd3459bf7b46aeca1bba0R1-R18)

### Actualizaciones en la Configuración de Compilación:
* Se actualizó `astro.config.mjs` para incluir opciones de Rollup que permiten personalizar el nombramiento de archivos de recursos durante el proceso de compilación (`astro.config.mjs`), para evitar cualquier error de ruta de las imágenes al hacer build del proyecto.

### Actualizaciones de Dependencias y Scripts:
* Se añadieron `sharp` y `@types/node` como dependencias para soportar el procesamiento de imágenes y las definiciones de tipos (`package.json`).
* Se introdujeron nuevos scripts de npm (`predev`, `prebuild` y `placeholder`) para integrar el proceso de generación de marcadores de posición en los flujos de trabajo de desarrollo y compilación (`package.json`).

### Otras Actualizaciones:
* Se modificó la configuración de ESLint para permitir `console.info`, además de `warn` y `error` (`eslint.config.js`).
* Se habilitaron hooks de pre-scripts y post-script en `.npmrc` para un mejor control en la ejecución de scripts.

Vista previa del efecto:

https://github.com/user-attachments/assets/05bfa88c-cfed-4ab8-aac3-2048fa49c5c3
